### PR TITLE
Add tests for `SettingListener`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Breaking: Remove move ctor/operator for SettingListener. (#32)
+
 ## v0.1.0
 
 - Dev: Update serialize library to v0.1.0. (#34)

--- a/include/pajlada/settings/settinglistener.hpp
+++ b/include/pajlada/settings/settinglistener.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <pajlada/signals/scoped-connection.hpp>
-
 #include <mutex>
+#include <pajlada/signals/scoped-connection.hpp>
 
 namespace pajlada {
 
@@ -28,10 +27,10 @@ public:
     }
 
     void
-    setCB(Callback cb)
+    setCB(Callback callback)
     {
         std::unique_lock<std::mutex> lock(this->cbMutex);
-        this->cb = cb;
+        this->cb = callback;
     }
 
     void
@@ -41,23 +40,8 @@ public:
         this->cb = std::function<void()>();
     }
 
-    SettingListener(SettingListener &&other) noexcept
-    {
-        this->cb = std::move(other.cb);
-
-        this->managedConnections.swap(other.managedConnections);
-    }
-
-    SettingListener &
-    operator=(SettingListener &&other) noexcept
-    {
-        this->cb = std::move(other.cb);
-
-        this->managedConnections.swap(other.managedConnections);
-
-        return *this;
-    }
-
+    SettingListener(SettingListener &&other) = delete;
+    SettingListener &operator=(SettingListener &&other) = delete;
     SettingListener(const SettingListener &) = delete;
     SettingListener &operator=(const SettingListener &) = delete;
 

--- a/src/test/listener.cpp
+++ b/src/test/listener.cpp
@@ -1,0 +1,123 @@
+
+#include <atomic>
+
+#include "pajlada/settings/settinglistener.hpp"
+#include "test/common.hpp"
+
+using namespace pajlada::Settings;
+using namespace pajlada;
+using namespace std;
+
+TEST(Listener, simple)
+{
+    Setting<int> a("/listener/simple/a");
+    Setting<int> b("/listener/simple/b");
+
+    size_t invocations = 0;
+    SettingListener listener([&] { invocations++; });
+
+    ASSERT_EQ(invocations, 0);
+    listener.addSetting(a);
+    ASSERT_EQ(invocations, 0);
+    listener.addSetting(b);
+    ASSERT_EQ(invocations, 0);
+
+    a = 42;
+    ASSERT_EQ(invocations, 1);
+    b = 42;
+    ASSERT_EQ(invocations, 2);
+    a = 42;
+    ASSERT_EQ(invocations, 3);
+    a = 1;
+    ASSERT_EQ(invocations, 4);
+}
+
+TEST(Listener, autoinvoke)
+{
+    Setting<int> a("/listener/autoinvoke/a");
+    Setting<int> b("/listener/autoinvoke/b");
+
+    size_t invocations = 0;
+    SettingListener listener([&] { invocations++; });
+
+    ASSERT_EQ(invocations, 0);
+    listener.addSetting(a, true);
+    ASSERT_EQ(invocations, 1);
+    listener.addSetting(b);
+    ASSERT_EQ(invocations, 1);
+
+    a = 42;
+    ASSERT_EQ(invocations, 2);
+    b = 42;
+    ASSERT_EQ(invocations, 3);
+    a = 42;
+    ASSERT_EQ(invocations, 4);
+    a = 1;
+    ASSERT_EQ(invocations, 5);
+}
+
+TEST(Listener, manualInvoke)
+{
+    Setting<int> a("/listener/manual-invoke/a");
+    Setting<int> b("/listener/manual-invoke/b");
+
+    size_t invocations = 0;
+    SettingListener listener([&] { invocations++; });
+
+    ASSERT_EQ(invocations, 0);
+    listener.addSetting(a);
+    ASSERT_EQ(invocations, 0);
+    listener.addSetting(b);
+    ASSERT_EQ(invocations, 0);
+
+    a = 42;
+    ASSERT_EQ(invocations, 1);
+    listener.invoke();
+    ASSERT_EQ(invocations, 2);
+    b = 42;
+    ASSERT_EQ(invocations, 3);
+}
+
+TEST(Listener, resetCallback)
+{
+    Setting<int> a("/listener/reset-callback/a");
+    Setting<int> b("/listener/reset-callback/b");
+
+    size_t invocations = 0;
+    SettingListener listener([&] { invocations++; });
+
+    ASSERT_EQ(invocations, 0);
+    listener.addSetting(a);
+    ASSERT_EQ(invocations, 0);
+    listener.addSetting(b);
+    ASSERT_EQ(invocations, 0);
+
+    a = 42;
+    ASSERT_EQ(invocations, 1);
+    listener.resetCB();
+    ASSERT_EQ(invocations, 1);
+    b = 42;
+    a = 42;
+    listener.invoke();
+    ASSERT_EQ(invocations, 1);
+}
+
+TEST(Listener, emptyCallback)
+{
+    Setting<int> a("/listener/empty-callback/a");
+    Setting<int> b("/listener/empty-callback/b");
+
+    SettingListener listener;
+
+    listener.addSetting(a);
+    listener.addSetting(b);
+
+    b = 42;
+    a = 42;
+    listener.invoke();
+
+    listener.resetCB();
+    b = 42;
+    a = 42;
+    listener.invoke();
+}


### PR DESCRIPTION
This adds tests for `SettingListener`. While tesing I noticed that the move constructor isn't working as expected. If I understood correctly, the following test should pass.

```cpp
TEST(Listener, move)
{
    Setting<int> a("/listener/move/a");
    Setting<int> b("/listener/move/b");

    size_t invocations = 0;
    SettingListener listener([&] { invocations++; });

    ASSERT_EQ(invocations, 0);
    listener.addSetting(a);
    ASSERT_EQ(invocations, 0);
    listener.addSetting(b);
    ASSERT_EQ(invocations, 0);

    a = 42;
    ASSERT_EQ(invocations, 1);
    b = 42;
    ASSERT_EQ(invocations, 2);
    SettingListener moved(std::move(listener));
    a = 42;
    ASSERT_EQ(invocations, 3);
    b = 42;
    ASSERT_EQ(invocations, 4);
}
```

This test fails however (`ASSERT_EQ(invocations, 3) - 2 != 3`, because the connections inside the listener will call the moved-from instance of the `SettingListener` (`cb` is empty there).