### PR TITLE
Add a .clang-tidy file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,69 @@
+Checks: "*,
+  -llvmlibc-*,
+  -altera-*,
+  -fuchsia-*,
+
+  hicpp-*,
+  google-*,
+  -google-build-using-namespace,
+  clang-diagnostic-*,
+  llvm-*,
+  misc-*,
+  -misc-unused-parameters,
+  readability-identifier-naming,
+  -llvm-header-guard,
+  -llvm-include-order,
+  modernize-*,
+  readability-*,
+  performance-*,
+  misc-*,
+  bugprone-*,
+  cert-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -readability-magic-numbers,
+  -performance-noexcept-move-constructor,
+  -misc-non-private-member-variables-in-classes,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-special-member-functions,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  -readability-identifier-length,
+  -readability-function-cognitive-complexity,
+  -bugprone-easily-swappable-parameters,
+  -cert-err58-cpp,
+  "
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  - key: readability-identifier-naming.MemberCase
+    value: camelBack
+  - key: readability-identifier-naming.PrivateMemberIgnoredRegexp
+    value: .*
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key: readability-identifier-naming.ProtectedMemberSuffix
+    value: _
+  - key: readability-identifier-naming.UnionCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+  - key: readability-implicit-bool-conversion.AllowPointerConditions
+    value: true
+
+  # Lua state
+  - key: readability-identifier-naming.LocalPointerIgnoredRegexp
+    value: ^L$

--- a/include/pajlada/settings/common.hpp
+++ b/include/pajlada/settings/common.hpp
@@ -51,10 +51,10 @@ operator==(const ValueResult<Type> &lhs, const ValueResult<Type> &rhs)
 }
 
 enum class SettingOption : uint32_t {
-    DoNotWriteToJSON = (1ull << 1ull),
+    DoNotWriteToJSON = (1ULL << 1ULL),
 
     /// A remote setting is a setting that is never saved locally, nor registered locally with any callbacks or anything
-    Remote = (1ull << 2ull),
+    Remote = (1ULL << 2ULL),
 
     Default = 0,
 };

--- a/include/pajlada/settings/setting.hpp
+++ b/include/pajlada/settings/setting.hpp
@@ -13,7 +13,7 @@
 
 namespace pajlada::Settings {
 
-namespace {
+namespace detail {
 
 inline SignalArgs
 onConnectArgs()
@@ -28,7 +28,7 @@ onConnectArgs()
     return a;
 }
 
-}  // namespace
+}  // namespace detail
 
 // A default value passed to a setting is only local to this specific instance of the setting
 // it is never shared between other settings at the same path
@@ -428,7 +428,7 @@ public:
             if (ptr != nullptr) {
                 d.CopyFrom(*ptr, d.GetAllocator());
             }
-            connection.invoke(std::move(d), onConnectArgs());
+            connection.invoke(std::move(d), detail::onConnectArgs());
         }
 
         this->managedConnections.emplace_back(
@@ -455,7 +455,7 @@ public:
             if (ptr != nullptr) {
                 d.CopyFrom(*ptr, d.GetAllocator());
             }
-            connection.invoke(std::move(d), onConnectArgs());
+            connection.invoke(std::move(d), detail::onConnectArgs());
         }
 
         userDefinedManagedConnections.emplace_back(
@@ -478,7 +478,7 @@ public:
             });
 
         if (autoInvoke) {
-            func(this->getValue(), onConnectArgs());
+            func(this->getValue(), detail::onConnectArgs());
         }
 
         this->managedConnections.emplace_back(
@@ -502,7 +502,7 @@ public:
             });
 
         if (autoInvoke) {
-            func(this->getValue(), onConnectArgs());
+            func(this->getValue(), detail::onConnectArgs());
         }
 
         userDefinedManagedConnections.emplace_back(
@@ -617,7 +617,7 @@ public:
             });
 
         if (autoInvoke) {
-            func(onConnectArgs());
+            func(detail::onConnectArgs());
         }
 
         this->managedConnections.emplace_back(
@@ -641,7 +641,7 @@ public:
             });
 
         if (autoInvoke) {
-            func(onConnectArgs());
+            func(detail::onConnectArgs());
         }
 
         userDefinedManagedConnections.emplace_back(

--- a/include/pajlada/settings/setting.hpp
+++ b/include/pajlada/settings/setting.hpp
@@ -215,7 +215,7 @@ public:
     void
     push_back(typename T::value_type newItem, SignalArgs &&args = SignalArgs())
     {
-        // TODO: refresh this->value first?
+        // TODO(pajlada): refresh this->value first?
         this->valueMutex.lock();
         if (!this->value) {
             this->value = Type{};
@@ -233,7 +233,7 @@ public:
     removeByValue(const typename T::value_type &key,
                   SignalArgs &&args = SignalArgs())
     {
-        // TODO: refresh this->value first?
+        // TODO(pajlada): refresh this->value first?
 
         T copy;
 

--- a/include/pajlada/settings/setting.hpp
+++ b/include/pajlada/settings/setting.hpp
@@ -11,8 +11,7 @@
 #include <pajlada/signals.hpp>
 #include <type_traits>
 
-namespace pajlada {
-namespace Settings {
+namespace pajlada::Settings {
 
 namespace {
 
@@ -671,5 +670,4 @@ private:
     std::vector<std::unique_ptr<Signals::ScopedConnection>> managedConnections;
 };
 
-}  // namespace Settings
-}  // namespace pajlada
+}  // namespace pajlada::Settings

--- a/include/pajlada/settings/settingdata.hpp
+++ b/include/pajlada/settings/settingdata.hpp
@@ -16,8 +16,7 @@
 #include <string>
 #include <vector>
 
-namespace pajlada {
-namespace Settings {
+namespace pajlada::Settings {
 
 class SettingData
 {
@@ -90,5 +89,4 @@ private:
     rapidjson::Value *get() const;
 };
 
-}  // namespace Settings
-}  // namespace pajlada
+}  // namespace pajlada::Settings

--- a/include/pajlada/settings/settinglistener.hpp
+++ b/include/pajlada/settings/settinglistener.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <mutex>
 #include <pajlada/signals/scoped-connection.hpp>
+#include <utility>
 #include <vector>
 
 namespace pajlada {
@@ -23,16 +24,15 @@ public:
     }
 
     SettingListener(Callback callback)
+        : cb(std::move(callback))
     {
-        std::unique_lock<std::mutex> lock(this->cbMutex);
-        this->cb = callback;
     }
 
     void
     setCB(Callback callback)
     {
         std::unique_lock<std::mutex> lock(this->cbMutex);
-        this->cb = callback;
+        this->cb = std::move(callback);
     }
 
     void

--- a/include/pajlada/settings/settingmanager.hpp
+++ b/include/pajlada/settings/settingmanager.hpp
@@ -12,8 +12,7 @@
 #include <pajlada/settings/signalargs.hpp>
 #include <vector>
 
-namespace pajlada {
-namespace Settings {
+namespace pajlada::Settings {
 
 class SettingData;
 
@@ -163,5 +162,4 @@ private:
     std::map<std::string, std::shared_ptr<SettingData>> settings;
 };
 
-}  // namespace Settings
-}  // namespace pajlada
+}  // namespace pajlada::Settings

--- a/include/pajlada/settings/settingmanager.hpp
+++ b/include/pajlada/settings/settingmanager.hpp
@@ -113,8 +113,8 @@ public:
     // on the statically initialized SettingManager instance
 
     enum class SaveMethod : uint64_t {
-        SaveOnExit = (1ull << 1ull),
-        SaveOnSettingChange = (1ull << 2ull),
+        SaveOnExit = (1ULL << 1ULL),
+        SaveOnSettingChange = (1ULL << 2ULL),
 
         // Force user to manually call SettingsManager::save() to save
         SaveManually = 0,

--- a/include/pajlada/settings/signalargs.hpp
+++ b/include/pajlada/settings/signalargs.hpp
@@ -6,8 +6,7 @@
 
 #include <string>
 
-namespace pajlada {
-namespace Settings {
+namespace pajlada::Settings {
 
 struct SignalArgs {
     SignalArgs() = default;
@@ -35,5 +34,4 @@ struct SignalArgs {
     bool writeToFile{true};
 };
 
-}  // namespace Settings
-}  // namespace pajlada
+}  // namespace pajlada::Settings

--- a/src/settings/detail/realpath.cpp
+++ b/src/settings/detail/realpath.cpp
@@ -2,9 +2,7 @@
 #include <pajlada/settings/internal.hpp>
 #include <unordered_set>
 
-namespace pajlada {
-namespace Settings {
-namespace detail {
+namespace pajlada::Settings::detail {
 
 fs::path
 RealPath(const fs::path &_path, fs_error_code &ec)
@@ -57,6 +55,4 @@ RealPath(const fs::path &_path, fs_error_code &ec)
     return path;
 }
 
-}  // namespace detail
-}  // namespace Settings
-}  // namespace pajlada
+}  // namespace pajlada::Settings::detail

--- a/src/settings/settingdata.cpp
+++ b/src/settings/settingdata.cpp
@@ -1,11 +1,12 @@
 #include <pajlada/settings/settingdata.hpp>
+#include <utility>
 
 namespace pajlada::Settings {
 
 SettingData::SettingData(std::string _path,
                          std::weak_ptr<SettingManager> _instance)
     : path(std::move(_path))
-    , instance(_instance)
+    , instance(std::move(_instance))
 {
 }
 

--- a/src/settings/settingdata.cpp
+++ b/src/settings/settingdata.cpp
@@ -1,7 +1,6 @@
 #include <pajlada/settings/settingdata.hpp>
 
-namespace pajlada {
-namespace Settings {
+namespace pajlada::Settings {
 
 SettingData::SettingData(std::string _path,
                          std::weak_ptr<SettingManager> _instance)
@@ -41,5 +40,4 @@ SettingData::get() const
     return locked->get(this->path.c_str());
 }
 
-}  // namespace Settings
-}  // namespace pajlada
+}  // namespace pajlada::Settings

--- a/src/settings/settingmanager.cpp
+++ b/src/settings/settingmanager.cpp
@@ -128,7 +128,7 @@ SettingManager::arraySize(const std::string &path)
     auto *valuePointer =
         rapidjson::Pointer(path.c_str()).Get(instance->document);
     if (valuePointer == nullptr) {
-        return false;
+        return 0;
     }
 
     rapidjson::Value &value = *valuePointer;

--- a/src/settings/settingmanager.cpp
+++ b/src/settings/settingmanager.cpp
@@ -503,6 +503,7 @@ SettingManager::saveAs(const fs::path &_path)
     fs::rename(tmpPath, path, ec);
 
     if (ec) {
+        // TODO(pajlada): Print the error code somewhere?
         return false;
     }
 

--- a/src/settings/settingmanager.cpp
+++ b/src/settings/settingmanager.cpp
@@ -9,8 +9,7 @@
 #include <pajlada/settings/settingmanager.hpp>
 #include <string>
 
-namespace pajlada {
-namespace Settings {
+namespace pajlada::Settings {
 
 SettingManager::SettingManager()
     : document(rapidjson::kObjectType)
@@ -574,5 +573,4 @@ SettingManager::getSetting(const std::string &path)
     return it->second;
 }
 
-}  // namespace Settings
-}  // namespace pajlada
+}  // namespace pajlada::Settings

--- a/src/settings/settingmanager.cpp
+++ b/src/settings/settingmanager.cpp
@@ -125,7 +125,7 @@ SettingManager::arraySize(const std::string &path)
 {
     const auto &instance = SettingManager::getInstance();
 
-    auto valuePointer =
+    auto *valuePointer =
         rapidjson::Pointer(path.c_str()).Get(instance->document);
     if (valuePointer == nullptr) {
         return false;
@@ -153,7 +153,7 @@ SettingManager::isNull(const std::string &path)
 bool
 SettingManager::_isNull(const std::string &path)
 {
-    auto valuePointer = rapidjson::Pointer(path.c_str()).Get(this->document);
+    auto *valuePointer = rapidjson::Pointer(path.c_str()).Get(this->document);
     if (valuePointer == nullptr) {
         return true;
     }
@@ -190,7 +190,7 @@ SettingManager::removeArrayValue(const std::string &arrayPath,
         return false;
     }
 
-    auto valuePointer =
+    auto *valuePointer =
         rapidjson::Pointer(arrayPath.c_str()).Get(instance->document);
     if (valuePointer == nullptr) {
         return false;
@@ -241,7 +241,7 @@ SettingManager::getObjectKeys(const std::string &objectPath)
 
     std::vector<std::string> ret;
 
-    auto root = instance->get(objectPath.c_str());
+    auto *root = instance->get(objectPath.c_str());
 
     if (root == nullptr || !root->IsObject()) {
         return ret;

--- a/src/settings/settingmanager.cpp
+++ b/src/settings/settingmanager.cpp
@@ -51,7 +51,7 @@ SettingManager::stringify(const rapidjson::Value &v)
     rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
     v.Accept(writer);
 
-    return std::string(buffer.GetString());
+    return {buffer.GetString()};
 }
 
 rapidjson::Value *


### PR DESCRIPTION
- Add the .clang-tidy file
- concat namespaces
- uppercase literal suffix
- move onConnectArgs to a non-anonymous namespace
- add name to todo comments
- std::move where possible
- don't repeat type
- auto star where possible
- don't cast false to 0
