### PR TITLE
fix: Update `updateIteration` when getting default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Breaking: Remove move ctor/operator for SettingListener. (#32)
+- Bugfix: Fixed an issue where settings without a value would always try to unmarshal the internal JSON. (#40)
 - Dev: Remove `using namespace std` usages. (#38)
 
 ## v0.1.0

--- a/include/pajlada/settings/common.hpp
+++ b/include/pajlada/settings/common.hpp
@@ -36,20 +36,6 @@ using OptionalType = std::optional<T>;
 const std::nullopt_t OptionalNull = std::nullopt;
 #endif
 
-template <typename Type>
-struct ValueResult {
-    OptionalType<Type> value;
-    int updateIteration;
-};
-
-template <typename Type>
-inline bool
-operator==(const ValueResult<Type> &lhs, const ValueResult<Type> &rhs)
-{
-    return std::tie(lhs.value, lhs.updateIteration) ==
-           std::tie(rhs.value, rhs.updateIteration);
-}
-
 enum class SettingOption : uint32_t {
     DoNotWriteToJSON = (1ULL << 1ULL),
 

--- a/include/pajlada/settings/setting.hpp
+++ b/include/pajlada/settings/setting.hpp
@@ -391,6 +391,13 @@ public:
         return SettingManager::removeSetting(this->getPath());
     }
 
+    int
+    getUpdateIteration() const
+    {
+        std::lock_guard guard(this->valueMutex);
+        return this->updateIteration;
+    }
+
 private:
     std::weak_ptr<SettingData> data;
     SettingOption options = SettingOption::Default;

--- a/include/pajlada/settings/setting.hpp
+++ b/include/pajlada/settings/setting.hpp
@@ -160,7 +160,8 @@ public:
             return this->defaultValue;
         }
 
-        if (this->updateIteration == lockedSetting->getUpdateIteration()) {
+        auto currentUpdateIteration = lockedSetting->getUpdateIteration();
+        if (this->updateIteration == currentUpdateIteration) {
             // Value hasn't been updated
             if (this->value) {
                 return *this->value;
@@ -168,11 +169,11 @@ public:
 
             return this->defaultValue;
         }
+        this->updateIteration = currentUpdateIteration;
 
         auto p = lockedSetting->template unmarshal<Type>();
-        if (p.value) {
-            this->value = p.value;
-            this->updateIteration = p.updateIteration;
+        if (p) {
+            this->value = std::forward<decltype(p)>(p);
         }
 
         if (this->value) {

--- a/include/pajlada/settings/settingdata.hpp
+++ b/include/pajlada/settings/settingdata.hpp
@@ -69,16 +69,16 @@ public:
     }
 
     template <typename Type>
-    ValueResult<Type>
+    OptionalType<Type>
     unmarshal() const
     {
         auto *ptr = this->get();
 
         if (ptr == nullptr) {
-            return {OptionalNull, -1};
+            return OptionalNull;
         }
 
-        return {Deserialize<Type>::get(*ptr), this->getUpdateIteration()};
+        return Deserialize<Type>::get(*ptr);
     }
 
     int getUpdateIteration() const;

--- a/src/test/bad-instance.cpp
+++ b/src/test/bad-instance.cpp
@@ -40,12 +40,11 @@ TEST(BadInstance, Two)
     sm1.reset();
 
     rapidjson::Value val;
-    ValueResult<int> p{std::nullopt, -1};
 
     EXPECT_TRUE(lockedData->marshal<int>(53) == false);
     EXPECT_TRUE(lockedData->unmarshalJSON() == nullptr);
     EXPECT_TRUE(lockedData->getPath() == "/multi/a");
-    EXPECT_TRUE(lockedData->unmarshal<int>() == p);
+    EXPECT_TRUE(lockedData->unmarshal<int>() == std::nullopt);
 
     a.getValue();
 }

--- a/src/test/default.cpp
+++ b/src/test/default.cpp
@@ -146,3 +146,18 @@ TEST(Default, Reset)
     EXPECT_TRUE(loadedSameCustomDefault.getDefaultValue() == 5);
     EXPECT_TRUE(loadedDifferentCustomDefault.getDefaultValue() == 5);
 }
+
+TEST(Default, UpdateUpdateIteration)
+{
+    SettingManager::clear();
+
+    Setting<int> setting("/setting", 42);
+
+    EXPECT_EQ(setting.getUpdateIteration(), -1);
+
+    EXPECT_TRUE(LoadFile("empty.json"));
+    EXPECT_EQ(setting.getUpdateIteration(), -1);
+
+    EXPECT_EQ(setting.getValue(), 42);
+    EXPECT_EQ(setting.getUpdateIteration(), 0);
+}

--- a/src/test/default.cpp
+++ b/src/test/default.cpp
@@ -160,4 +160,9 @@ TEST(Default, UpdateUpdateIteration)
 
     EXPECT_EQ(setting.getValue(), 42);
     EXPECT_EQ(setting.getUpdateIteration(), 0);
+
+    setting = 43;
+    EXPECT_EQ(setting.getUpdateIteration(), 0);
+    EXPECT_EQ(setting.getValue(), 43);
+    EXPECT_EQ(setting.getUpdateIteration(), 1);
 }


### PR DESCRIPTION
When calling `Setting::getValue` on a setting that doesn't have a value (it has the default value), the `updateIteration` wasn't updated. This results in subsequent calls calling `unmarshal` on the setting even though we know it hasn't changed.