### PR TITLE
chore: add VS (-Code) and IntelliJ directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ compile_commands.json
 /.cache
 
 CMakeUserPresets.json
+
+# editors
+.vscode
+.vs
+.idea


### PR DESCRIPTION
These are the editor directories of the respective editors, which should be ignored.