### PR TITLE
refactor: move from `boost::any` to `std::any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Breaking: Remove move ctor/operator for SettingListener. (#32)
 - Breaking: Updated to C++20. (#42)
 - Breaking: Remove boost::any `userData` support. (#44)
+- Breaking: Remove support for `boost::any`. (#46)
+- Minor: Added support for `std::any`. (#46)
 - Bugfix: Fixed an issue where settings without a value would always try to unmarshal the internal JSON. (#40)
 - Dev: Remove `using namespace std` usages. (#38)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,6 @@ if (PAJLADA_SETTINGS_BUILD_TESTS)
     add_test(AllTestsXD settings-test)
 
     target_compile_definitions(settings-test PRIVATE PAJLADA_SETTINGS_DEBUG)
-    # target_compile_definitions(settings-test PRIVATE PAJLADA_BOOST_ANY_SUPPORT)
     # target_compile_definitions(settings-test PRIVATE PAJLADA_SETTINGS_BOOST_FILESYSTEM)
 
     set_property(TARGET settings-test PROPERTY CXX_STANDARD ${PAJLADA_SETTINGS_CXX_STANDARD})

--- a/include/pajlada/settings/equal.hpp
+++ b/include/pajlada/settings/equal.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
-#include <boost/any.hpp>
-#endif
-
+#include <any>
 #include <map>
 #include <vector>
 
@@ -28,17 +25,15 @@ struct IsEqual<std::pair<Type1, Type2>> {
     }
 };
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
 template <>
-struct IsEqual<boost::any> {
+struct IsEqual<std::any> {
     static bool
-    get(const boost::any &lhs, const boost::any &rhs)
+    get(const std::any &lhs, const std::any &rhs)
     {
-        // two boost::any cannot be safely compared to each other, so we only consider them equal if both are empty
-        return (lhs.empty() && rhs.empty());
+        // two std::any cannot be safely compared to each other, so we only consider them equal if both are empty
+        return (!lhs.has_value() && !rhs.has_value());
     }
 };
-#endif
 
 template <typename KeyType, typename ValueType>
 struct IsEqual<std::map<KeyType, ValueType>> {
@@ -54,12 +49,11 @@ struct IsEqual<std::map<KeyType, ValueType>> {
     }
 };
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
 template <typename KeyType>
-struct IsEqual<std::map<KeyType, boost::any>> {
+struct IsEqual<std::map<KeyType, std::any>> {
     static bool
-    get(const std::map<KeyType, boost::any> &lhs,
-        const std::map<KeyType, boost::any> &rhs)
+    get(const std::map<KeyType, std::any> &lhs,
+        const std::map<KeyType, std::any> &rhs)
     {
         if (lhs.size() != rhs.size()) {
             return false;
@@ -72,7 +66,7 @@ struct IsEqual<std::map<KeyType, boost::any>> {
                 return false;
             }
 
-            if (!IsEqual<boost::any>::get(p.second, rit->second)) {
+            if (!IsEqual<std::any>::get(p.second, rit->second)) {
                 return false;
             }
         }
@@ -80,7 +74,6 @@ struct IsEqual<std::map<KeyType, boost::any>> {
         return true;
     }
 };
-#endif
 
 template <typename ValueType>
 struct IsEqual<std::vector<ValueType>> {
@@ -95,11 +88,10 @@ struct IsEqual<std::vector<ValueType>> {
     }
 };
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
 template <>
-struct IsEqual<std::vector<boost::any>> {
+struct IsEqual<std::vector<std::any>> {
     static bool
-    get(const std::vector<boost::any> &lhs, const std::vector<boost::any> &rhs)
+    get(const std::vector<std::any> &lhs, const std::vector<std::any> &rhs)
     {
         if (lhs.size() != rhs.size()) {
             return false;
@@ -113,7 +105,7 @@ struct IsEqual<std::vector<boost::any>> {
                 return false;
             }
 
-            if (!IsEqual<boost::any>::get(*lit, *rit)) {
+            if (!IsEqual<std::any>::get(*lit, *rit)) {
                 return false;
             }
         }
@@ -121,6 +113,5 @@ struct IsEqual<std::vector<boost::any>> {
         return true;
     }
 };
-#endif
 
 }  // namespace pajlada

--- a/include/pajlada/settings/signalargs.hpp
+++ b/include/pajlada/settings/signalargs.hpp
@@ -1,9 +1,5 @@
 #pragma once
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
-#include <boost/any.hpp>
-#endif
-
 #include <string>
 
 namespace pajlada::Settings {

--- a/src/test/map.cpp
+++ b/src/test/map.cpp
@@ -4,12 +4,11 @@
 
 using namespace pajlada::Settings;
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
 TEST(Map, Simple)
 {
-    using boost::any_cast;
+    using std::any_cast;
 
-    Setting<std::map<std::string, boost::any>> test("/map");
+    Setting<std::map<std::string, std::any>> test("/map");
 
     EXPECT_TRUE(LoadFile("in.simplemap.json"));
 
@@ -17,7 +16,7 @@ TEST(Map, Simple)
     EXPECT_TRUE(myMap.size() == 3);
     EXPECT_TRUE(any_cast<int>(myMap["a"]) == 1);
     EXPECT_TRUE(any_cast<std::string>(myMap["b"]) == "asd");
-    EXPECT_TRUE(any_cast<double>(myMap["c"]) == 3.14);
+    EXPECT_DOUBLE_EQ(any_cast<double>(myMap["c"]), 3.14);
 
     std::vector<std::string> keys{"a", "b", "c"};
 
@@ -28,9 +27,9 @@ TEST(Map, Simple)
 
 TEST(Map, Complex)
 {
-    using boost::any_cast;
+    using std::any_cast;
 
-    Setting<std::map<std::string, boost::any>> test("/map");
+    Setting<std::map<std::string, std::any>> test("/map");
 
     EXPECT_TRUE(LoadFile("in.complexmap.json"));
 
@@ -39,13 +38,13 @@ TEST(Map, Complex)
     EXPECT_TRUE(any_cast<int>(myMap["a"]) == 5);
 
     auto innerMap =
-        any_cast<std::map<std::string, boost::any>>(myMap["innerMap"]);
+        any_cast<std::map<std::string, std::any>>(myMap["innerMap"]);
     EXPECT_TRUE(innerMap.size() == 3);
     EXPECT_TRUE(any_cast<int>(innerMap["a"]) == 420);
     EXPECT_TRUE(any_cast<int>(innerMap["b"]) == 320);
-    EXPECT_TRUE(any_cast<double>(innerMap["c"]) == 13.37);
+    EXPECT_DOUBLE_EQ(any_cast<double>(innerMap["c"]), 13.37);
 
-    auto innerArray = any_cast<std::vector<boost::any>>(myMap["innerArray"]);
+    auto innerArray = any_cast<std::vector<std::any>>(myMap["innerArray"]);
     EXPECT_TRUE(innerArray.size() == 9);
     EXPECT_TRUE(any_cast<int>(innerArray[0]) == 1);
     EXPECT_TRUE(any_cast<int>(innerArray[1]) == 2);
@@ -54,10 +53,10 @@ TEST(Map, Complex)
     EXPECT_TRUE(any_cast<std::string>(innerArray[4]) == "testman");
     EXPECT_TRUE(any_cast<bool>(innerArray[5]) == true);
     EXPECT_TRUE(any_cast<bool>(innerArray[6]) == false);
-    EXPECT_TRUE(any_cast<double>(innerArray[7]) == 4.20);
+    EXPECT_DOUBLE_EQ(any_cast<double>(innerArray[7]), 4.20);
 
     auto innerArrayMap =
-        any_cast<std::map<std::string, boost::any>>(innerArray[8]);
+        any_cast<std::map<std::string, std::any>>(innerArray[8]);
     EXPECT_TRUE(innerArrayMap.size() == 3);
     EXPECT_TRUE(any_cast<int>(innerArrayMap["a"]) == 1);
     EXPECT_TRUE(any_cast<int>(innerArrayMap["b"]) == 2);
@@ -65,4 +64,3 @@ TEST(Map, Complex)
 
     EXPECT_TRUE(SettingManager::gSaveAs("files/out.complexmap.json"));
 }
-#endif

--- a/src/test/misc.cpp
+++ b/src/test/misc.cpp
@@ -16,16 +16,14 @@
 using namespace pajlada::Settings;
 using namespace pajlada::test;
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
-TEST(Misc, BoostAny)
+TEST(Misc, StdAny)
 {
-    Setting<boost::any> test("/anyTest");
-    auto test2 = new Setting<boost::any>("/anyTest2");
+    Setting<std::any> test("/anyTest");
+    auto test2 = new Setting<std::any>("/anyTest2");
 
     auto v1 = test.getValue();
     auto v2 = test2->getValue();
 }
-#endif
 
 TEST(Misc, Array)
 {

--- a/src/test/serialize.cpp
+++ b/src/test/serialize.cpp
@@ -50,34 +50,33 @@ TEST(Serialize, VectorMisc)
                            "out.serialize.vector.str.json"));
 }
 
-#ifdef PAJLADA_BOOST_ANY_SUPPORT
-TEST(Serialize, BoostAnyVectorString)
+TEST(Serialize, StdAnyVectorString)
 {
-    using boost::any_cast;
+    using std::any_cast;
 
     SettingManager::clear();
 
     std::vector<std::string> data{"a", "b", "c"};
 
-    Setting<boost::any> a("/a");
+    Setting<std::any> a("/a");
 
     auto rawAny = a.getValue();
-    EXPECT_TRUE(rawAny.empty());
+    EXPECT_FALSE(rawAny.has_value());
 
     a = data;
 
     rawAny = a.getValue();
 
-    EXPECT_TRUE(!rawAny.empty());
+    EXPECT_TRUE(rawAny.has_value());
 
-    auto vec = any_cast<std::vector<boost::any>>(rawAny);
+    auto vec = any_cast<std::vector<std::any>>(rawAny);
 
     EXPECT_TRUE(vec.size() == data.size());
 
     EXPECT_TRUE(LoadFile("in.serialize.any.vector.str.json"));
 
     rawAny = a.getValue();
-    vec = any_cast<std::vector<boost::any>>(rawAny);
+    vec = any_cast<std::vector<std::any>>(rawAny);
 
     EXPECT_TRUE(vec.size() == 2);
     EXPECT_TRUE(any_cast<std::string>(vec[0]) == "x");
@@ -93,23 +92,23 @@ TEST(Serialize, BoostAnyVectorString)
                            "out.serialize.any.vector.str.json"));
 }
 
-TEST(Serialize, BoostAnyVectorAny)
+TEST(Serialize, StdAnyVectorAny)
 {
-    using boost::any_cast;
+    using std::any_cast;
 
     SettingManager::clear();
 
-    std::vector<boost::any> data{"test", 5, 13.37};
+    std::vector<std::any> data{"test", 5, 13.37};
 
-    Setting<boost::any> a("/a");
+    Setting<std::any> a("/a");
 
     auto rawAny = a.getValue();
-    EXPECT_TRUE(rawAny.empty());
+    EXPECT_FALSE(rawAny.has_value());
 
     a = data;
 
     rawAny = a.getValue();
-    auto vec = any_cast<std::vector<boost::any>>(rawAny);
+    auto vec = any_cast<std::vector<std::any>>(rawAny);
 
     EXPECT_TRUE(vec.size() == data.size());
 
@@ -121,7 +120,7 @@ TEST(Serialize, BoostAnyVectorAny)
     EXPECT_TRUE(LoadFile("in.serialize.any.vector.str.json"));
 
     rawAny = a.getValue();
-    vec = any_cast<std::vector<boost::any>>(rawAny);
+    vec = any_cast<std::vector<std::any>>(rawAny);
 
     EXPECT_TRUE(vec.size() == 2);
     EXPECT_TRUE(any_cast<std::string>(vec[0]) == "x");
@@ -136,7 +135,6 @@ TEST(Serialize, BoostAnyVectorAny)
     EXPECT_TRUE(FilesMatch("in.serialize.vector.str.state1.json",
                            "out.serialize.any.vector.str.json"));
 }
-#endif
 
 TEST(Serialize, Int1)
 {


### PR DESCRIPTION
This removes support for `boost::any` and moves to `std::any`.