### PR TITLE
refactor: remove the last references to boost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Breaking: Remove boost::any `userData` support. (#44)
 - Breaking: Remove support for `boost::any`. (#46)
 - Breaking: Remove support for `boost::filesystem`. (#47)
+- Breaking: Remove support for `boost::optional`. (#48)
 - Minor: Added support for `std::any`. (#46)
 - Bugfix: Fixed an issue where settings without a value would always try to unmarshal the internal JSON. (#40)
 - Dev: Remove `using namespace std` usages. (#38)

--- a/include/pajlada/settings/common.hpp
+++ b/include/pajlada/settings/common.hpp
@@ -5,6 +5,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <queue>
 #include <set>
 #include <stack>
@@ -16,25 +17,9 @@
 #include <utility>
 #include <vector>
 
-#ifdef PAJLADA_SETTINGS_BOOST_OPTIONAL
-#include <boost/optional.hpp>
-#else
-#include <optional>
-#endif
-
 namespace pajlada {
 
 namespace Settings {
-
-#ifdef PAJLADA_SETTINGS_BOOST_OPTIONAL
-template <typename T>
-using OptionalType = boost::optional<T>;
-const boost::none_t OptionalNull = boost::none;
-#else
-template <typename T>
-using OptionalType = std::optional<T>;
-const std::nullopt_t OptionalNull = std::nullopt;
-#endif
 
 enum class SettingOption : uint32_t {
     DoNotWriteToJSON = (1ULL << 1ULL),

--- a/include/pajlada/settings/setting.hpp
+++ b/include/pajlada/settings/setting.hpp
@@ -376,7 +376,7 @@ public:
     }
 
     // Returns true if the current value is the same as the default value
-    // boost::any cannot be properly compared
+    // std::any cannot be properly compared
     bool
     isDefaultValue() const
     {

--- a/include/pajlada/settings/setting.hpp
+++ b/include/pajlada/settings/setting.hpp
@@ -406,7 +406,7 @@ private:
 
     // These are mutable because they can be modified from the "getValue" function
     mutable std::mutex valueMutex;
-    mutable OptionalType<Type> value;
+    mutable std::optional<Type> value;
     mutable int updateIteration = -1;
 
 public:

--- a/include/pajlada/settings/settingdata.hpp
+++ b/include/pajlada/settings/settingdata.hpp
@@ -69,13 +69,13 @@ public:
     }
 
     template <typename Type>
-    OptionalType<Type>
+    std::optional<Type>
     unmarshal() const
     {
         auto *ptr = this->get();
 
         if (ptr == nullptr) {
-            return OptionalNull;
+            return std::nullopt;
         }
 
         return Deserialize<Type>::get(*ptr);


### PR DESCRIPTION
* Removes `PAJLADA_SETTINGS_BOOST_OPTIONAL` (undocumented)
* Updates a comment I missed in #46

The only references to boost are now in the changelog.