### PR TITLE
feat: use `MOVEFILE_WRITE_THROUGH` when renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Breaking: Remove support for `boost::any`. (#46)
 - Breaking: Remove support for `boost::filesystem`. (#47)
 - Breaking: Remove support for `boost::optional`. (#48)
+- Major: On Windows, use platform-specific [MOVEFILE_WRITE_THROUGH](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw#movefile_write_through) flag ensuring the move takes place before the function returns. (#87)
 - Minor: Added setting option `CompareBeforeSet` which compares the old & new value in `setValue` before trying to update the value. This compares the marshalled JSON blob the value makes. (#74)
 - Minor: Added support for `std::any`. (#46)
 - Bugfix: Fixed an issue where settings without a value would always try to unmarshal the internal JSON. (#40)


### PR DESCRIPTION
On Windows, this will bypass the filesystem cache. As a consequence, writes should be a bit more "atomic", while introducing a bit more work for the actual filesystem. 

See also https://github.com/Chatterino/chatterino2/issues/3262