### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.0
+
 - Breaking: Remove move ctor/operator for SettingListener. (#32)
 - Breaking: Updated to C++20. (#42)
 - Breaking: Remove boost::any `userData` support. (#44)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,11 @@ cmake_policy(SET CMP0091 NEW) # select MSVC runtime library through `CMAKE_MSVC_
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-project(PajladaSettings)
+project(PajladaSettings
+    VERSION 0.2.0
+    DESCRIPTION "Settings library"
+    HOMEPAGE_URL "https://github.com/pajlada/settings"
+)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
- Breaking: Remove move ctor/operator for SettingListener. (#32)
- Breaking: Updated to C++20. (#42)
- Breaking: Remove boost::any `userData` support. (#44)
- Breaking: Remove support for `boost::any`. (#46)
- Breaking: Remove support for `boost::filesystem`. (#47)
- Breaking: Remove support for `boost::optional`. (#48)
- Major: On Windows, use platform-specific [MOVEFILE_WRITE_THROUGH](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw#movefile_write_through) flag ensuring the move takes place before the function returns. (#87)
- Minor: Added setting option `CompareBeforeSet` which compares the old & new value in `setValue` before trying to update the value. This compares the marshalled JSON blob the value makes. (#74)
- Minor: Added support for `std::any`. (#46)
- Bugfix: Fixed an issue where settings without a value would always try to unmarshal the internal JSON. (#40)
- Dev: Remove `using namespace std` usages. (#38)