### PR TITLE
feat: add backup API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Minor: Added standalone backup API `pajlada::Settings::Backup::saveWithBackup` in `backup.hpp` (#90)
+
 ## v0.2.0
 
 - Breaking: Remove move ctor/operator for SettingListener. (#32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,11 @@ if (PAJLADA_SETTINGS_USE_CONAN)
 endif ()
 
 set(PajladaSettings_SOURCES
+    src/settings/backup.cpp
     src/settings/settingdata.cpp
     src/settings/settingmanager.cpp
 
+    src/settings/detail/rename.cpp
     src/settings/detail/realpath.cpp
     )
 

--- a/include/pajlada/settings/backup.hpp
+++ b/include/pajlada/settings/backup.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <filesystem>
+#include <functional>
+#include <system_error>
+
+namespace pajlada::Settings::Backup {
+
+struct Options {
+    /// Whether the backup is done or not
+    bool enabled = true;
+    /// The number of backup files to use
+    std::uint8_t slots = 3;
+};
+
+/// @brief Orchestrates saving of a file (`path`) with optional backups
+///
+/// The save operation works as follows:
+/// 1. The desired contents are written to a temporary file by `doWrite`
+/// 2. Past backups are shifted by one (`.bkp-1` -> `.bkp-2`; `.bkp-2` ->
+///    `.bkp-3` etc.)
+/// 3. The current file (`path` - not the temporary one) is moved to the backup
+///    (`.bkp-1`)
+/// 4. The temporary file from step 1 is moved to the current file (`path`)
+///
+/// The procedure is successful if and only if the value of `ec` is `0` after
+/// calling this function.
+///
+/// @param path The file path to save to ("current file")
+/// @param options Options for the backup procedure (e.g. number of backup
+///                files)
+/// @param doWrite A callback to perform the write of the actual data. The
+///                callback _must_ use the path passed to the callback instead
+///                of the one passed to this function.
+/// @param ec An error code to bubble up errors from operations done in this
+///           procedure.
+/// @returns Nothing - the caller must check `ec`.
+void saveWithBackup(const std::filesystem::path &path, Options options,
+                    const std::function<void(const std::filesystem::path &,
+                                             std::error_code &ec)> &doWrite,
+                    std::error_code &ec);
+
+}  // namespace pajlada::Settings::Backup

--- a/include/pajlada/settings/detail/rename.hpp
+++ b/include/pajlada/settings/detail/rename.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <filesystem>
+
+namespace pajlada::Settings::detail {
+
+void renameFile(const std::filesystem::path &from,
+                const std::filesystem::path &to, std::error_code &ec);
+
+}  // namespace pajlada::Settings::detail

--- a/include/pajlada/settings/settingmanager.hpp
+++ b/include/pajlada/settings/settingmanager.hpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <pajlada/settings/backup.hpp>
 #include <pajlada/settings/common.hpp>
 #include <pajlada/settings/signalargs.hpp>
 #include <vector>
@@ -130,10 +131,7 @@ private:
                 static_cast<uint64_t>(testSaveMethod)) != 0;
     }
 
-    struct {
-        bool enabled{};
-        uint8_t numSlots = 3;
-    } backup;
+    Backup::Options backup;
 
 public:
     void setBackupEnabled(bool enabled = true);

--- a/src/settings/backup.cpp
+++ b/src/settings/backup.cpp
@@ -1,0 +1,68 @@
+#include <pajlada/settings/backup.hpp>
+#include <pajlada/settings/detail/realpath.hpp>
+#include <pajlada/settings/detail/rename.hpp>
+
+namespace pajlada::Settings::Backup {
+
+void
+saveWithBackup(const std::filesystem::path &path, Options options,
+               const std::function<void(const std::filesystem::path &,
+                                        std::error_code &ec)> &doWrite,
+               std::error_code &ec)
+{
+    std::filesystem::path realPath = detail::RealPath(path, ec);
+    if (ec) {
+        return;
+    }
+    std::filesystem::path tmpPath(path);
+    tmpPath += ".tmp";
+
+    std::filesystem::path bkpPath(path);
+    bkpPath += ".bkp";
+
+    doWrite(tmpPath, ec);
+    if (ec) {
+        return;
+    }
+
+    if (options.enabled) {
+        std::filesystem::path firstBkpPath(bkpPath);
+        firstBkpPath += "-" + std::to_string(1);
+
+        if (options.slots > 1) {
+            std::filesystem::path topBkpPath(bkpPath);
+            topBkpPath += "-" + std::to_string(options.slots);
+            topBkpPath = detail::RealPath(topBkpPath, ec);
+            if (ec) {
+                return;
+            }
+            // Remove top slot backup
+            std::filesystem::remove(topBkpPath, ec);
+
+            // Shift backups one slot up
+            for (uint8_t slotIndex = options.slots - 1; slotIndex >= 1;
+                 --slotIndex) {
+                std::filesystem::path p1(bkpPath);
+                p1 += "-" + std::to_string(slotIndex);
+                p1 = detail::RealPath(p1, ec);
+                if (ec) {
+                    return;
+                }
+                std::filesystem::path p2(bkpPath);
+                p2 += "-" + std::to_string(slotIndex + 1);
+                p2 = detail::RealPath(p2, ec);
+                if (ec) {
+                    return;
+                }
+                detail::renameFile(p1, p2, ec);
+            }
+        }
+
+        // Move current save to first backup slot
+        detail::renameFile(realPath, firstBkpPath, ec);
+    }
+
+    detail::renameFile(tmpPath, realPath, ec);
+}
+
+}  // namespace pajlada::Settings::Backup

--- a/src/settings/detail/rename.cpp
+++ b/src/settings/detail/rename.cpp
@@ -1,0 +1,28 @@
+#include <pajlada/settings/detail/rename.hpp>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
+namespace pajlada::Settings::detail {
+
+void
+renameFile(const std::filesystem::path &from, const std::filesystem::path &to,
+           std::error_code &ec)
+{
+#ifdef _WIN32
+    // MOVEFILE_WRITE_THROUGH to bypass the filesystem cache
+    if (MoveFileExW(from.c_str(), to.c_str(),
+                    MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING |
+                        MOVEFILE_WRITE_THROUGH) == TRUE) {
+        ec = {0, std::system_category()};
+    } else {
+        ec = {static_cast<int>(GetLastError()), std::system_category()};
+    }
+#else
+    std::filesystem::rename(from, to, ec);
+#endif
+}
+
+}  // namespace pajlada::Settings::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(${PROJECT_NAME}
     src/bad-instance.cpp
     src/misc.cpp
     src/listener.cpp
+    src/backup.cpp
 
     src/foo.cpp
     src/channel.cpp

--- a/tests/src/backup.cpp
+++ b/tests/src/backup.cpp
@@ -65,6 +65,61 @@ TEST(Backup, Basic)
     EXPECT_TRUE(fs::exists("files/out.backup.basic.json.bkp-3"));
 }
 
+TEST(Backup, Single)
+{
+    size_t writeCalls = 0;
+    auto doSave = [&] {
+        std::error_code ec;
+        Backup::saveWithBackup(
+            "files/out.backup.single.json", {.enabled = true, .slots = 1},
+            [&](const auto &path, auto &ec) {
+                writeCalls++;
+                std::ofstream of(path, std::ios::out);
+                if (!of) {
+                    ec = std::make_error_code(std::errc::io_error);
+                    return;
+                }
+                of << "yo";
+            },
+            ec);
+        return !ec;
+    };
+
+    RemoveFile("files/out.backup.single.json");
+    RemoveFile("files/out.backup.single.json.bkp-1");
+
+    EXPECT_TRUE(!fs::exists("files/out.backup.single.json"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 1);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.single.json"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.single.json.bkp-1"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 2);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.single.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.single.json.bkp-1"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.single.json.bkp-2"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 3);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.single.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.single.json.bkp-1"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.single.json.bkp-2"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.single.json.bkp-3"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 4);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.single.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.single.json.bkp-1"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.single.json.bkp-2"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.single.json.bkp-3"));
+}
+
 TEST(Backup, Disabled)
 {
     size_t writeCalls = 0;

--- a/tests/src/backup.cpp
+++ b/tests/src/backup.cpp
@@ -1,0 +1,191 @@
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <pajlada/settings/backup.hpp>
+
+#include "common.hpp"
+
+namespace fs = std::filesystem;
+namespace Backup = pajlada::Settings::Backup;
+
+TEST(Backup, Basic)
+{
+    size_t writeCalls = 0;
+    auto doSave = [&] {
+        std::error_code ec;
+        Backup::saveWithBackup(
+            "files/out.backup.basic.json", {.enabled = true, .slots = 3},
+            [&](const auto &path, auto &ec) {
+                writeCalls++;
+                std::ofstream of(path, std::ios::out);
+                if (!of) {
+                    ec = std::make_error_code(std::errc::io_error);
+                    return;
+                }
+                of << "yo";
+            },
+            ec);
+        return !ec;
+    };
+
+    RemoveFile("files/out.backup.basic.json");
+    RemoveFile("files/out.backup.basic.json.bkp-1");
+    RemoveFile("files/out.backup.basic.json.bkp-2");
+    RemoveFile("files/out.backup.basic.json.bkp-3");
+
+    EXPECT_TRUE(!fs::exists("files/out.backup.basic.json"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 1);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.basic.json.bkp-1"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 2);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json.bkp-1"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.basic.json.bkp-2"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 3);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json.bkp-1"));
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json.bkp-2"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.basic.json.bkp-3"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 4);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json.bkp-1"));
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json.bkp-2"));
+    EXPECT_TRUE(fs::exists("files/out.backup.basic.json.bkp-3"));
+}
+
+TEST(Backup, Disabled)
+{
+    size_t writeCalls = 0;
+    auto doSave = [&] {
+        std::error_code ec;
+        Backup::saveWithBackup(
+            "files/out.backup.disabled.json", {.enabled = false, .slots = 3},
+            [&](const auto &path, auto &ec) {
+                writeCalls++;
+                std::ofstream of(path, std::ios::out);
+                if (!of) {
+                    ec = std::make_error_code(std::errc::io_error);
+                    return;
+                }
+                of << "yo";
+            },
+            ec);
+        return !ec;
+    };
+
+    RemoveFile("files/out.backup.disabled.json");
+    RemoveFile("files/out.backup.disabled.json.bkp-1");
+    RemoveFile("files/out.backup.disabled.json.bkp-2");
+    RemoveFile("files/out.backup.disabled.json.bkp-3");
+
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 1);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.disabled.json"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json.bkp-1"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 2);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.disabled.json"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json.bkp-1"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json.bkp-2"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 3);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.disabled.json"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json.bkp-1"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json.bkp-2"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json.bkp-3"));
+
+    EXPECT_TRUE(doSave());
+    EXPECT_EQ(writeCalls, 4);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.disabled.json"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json.bkp-1"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json.bkp-2"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.disabled.json.bkp-3"));
+}
+
+TEST(Backup, Failing)
+{
+    size_t writeCalls = 0;
+    std::error_code ec;
+    auto doSave = [&](bool fail) {
+        Backup::saveWithBackup(
+            "files/out.backup.failing.json", {.enabled = true, .slots = 3},
+            [&](const auto &path, auto &ec) {
+                writeCalls++;
+                std::ofstream of(path, std::ios::out);
+                if (fail) {
+                    ec = std::make_error_code(std::errc::io_error);
+                }
+                of << "yo";
+            },
+            ec);
+        return !ec;
+    };
+
+    RemoveFile("files/out.backup.failing.json");
+    RemoveFile("files/out.backup.failing.json.bkp-1");
+    RemoveFile("files/out.backup.failing.json.bkp-2");
+    RemoveFile("files/out.backup.failing.json.bkp-3");
+
+    EXPECT_TRUE(!fs::exists("files/out.backup.failing.json"));
+
+    EXPECT_TRUE(doSave(false));
+    EXPECT_EQ(writeCalls, 1);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.failing.json.bkp-1"));
+
+    EXPECT_TRUE(doSave(false));
+    EXPECT_EQ(writeCalls, 2);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json.bkp-1"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.failing.json.bkp-2"));
+
+    EXPECT_FALSE(doSave(true));
+    EXPECT_EQ(writeCalls, 3);
+    EXPECT_EQ(ec, std::make_error_code(std::errc::io_error));
+    ec = {};
+
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json.bkp-1"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.failing.json.bkp-2"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.failing.json.bkp-3"));
+
+    EXPECT_TRUE(doSave(false));
+    EXPECT_EQ(writeCalls, 4);
+
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json.bkp-1"));
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json.bkp-2"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.failing.json.bkp-3"));
+
+    EXPECT_FALSE(doSave(true));
+    EXPECT_EQ(writeCalls, 5);
+    EXPECT_EQ(ec, std::make_error_code(std::errc::io_error));
+    ec = {};
+
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json"));
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json.bkp-1"));
+    EXPECT_TRUE(fs::exists("files/out.backup.failing.json.bkp-2"));
+    EXPECT_TRUE(!fs::exists("files/out.backup.failing.json.bkp-3"));
+}


### PR DESCRIPTION
Towards https://github.com/Chatterino/chatterino2/issues/2235. This adds a public backup API by moving the one from `SettingsMananger` to a generic, accessible function `pajlada::Settings::Backup::saveWithBackup`. It takes a callback where users write to the target (temporary) file, which is then backed up. `SettingsManager` was moved to this API and tests for the standalone API were added.