### PR TITLE
fix: rename `slots` to `numSlots`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bugfix: Renamed `slots` in the backup options to `numSlots` to avoid conflicts with Qt (#92)
+
 ## v0.2.1
 
 - Minor: Added standalone backup API `pajlada::Settings::Backup::saveWithBackup` in `backup.hpp` (#90)

--- a/include/pajlada/settings/backup.hpp
+++ b/include/pajlada/settings/backup.hpp
@@ -10,7 +10,7 @@ struct Options {
     /// Whether the backup is done or not
     bool enabled = true;
     /// The number of backup files to use
-    std::uint8_t slots = 3;
+    std::uint8_t numSlots = 3;
 };
 
 /// @brief Orchestrates saving of a file (`path`) with optional backups

--- a/src/settings/backup.cpp
+++ b/src/settings/backup.cpp
@@ -29,9 +29,9 @@ saveWithBackup(const std::filesystem::path &path, Options options,
         std::filesystem::path firstBkpPath(bkpPath);
         firstBkpPath += "-" + std::to_string(1);
 
-        if (options.slots > 1) {
+        if (options.numSlots > 1) {
             std::filesystem::path topBkpPath(bkpPath);
-            topBkpPath += "-" + std::to_string(options.slots);
+            topBkpPath += "-" + std::to_string(options.numSlots);
             topBkpPath = detail::RealPath(topBkpPath, ec);
             if (ec) {
                 return;
@@ -40,7 +40,7 @@ saveWithBackup(const std::filesystem::path &path, Options options,
             std::filesystem::remove(topBkpPath, ec);
 
             // Shift backups one slot up
-            for (uint8_t slotIndex = options.slots - 1; slotIndex >= 1;
+            for (uint8_t slotIndex = options.numSlots - 1; slotIndex >= 1;
                  --slotIndex) {
                 std::filesystem::path p1(bkpPath);
                 p1 += "-" + std::to_string(slotIndex);

--- a/src/settings/settingmanager.cpp
+++ b/src/settings/settingmanager.cpp
@@ -495,7 +495,7 @@ SettingManager::setBackupEnabled(bool enabled)
 void
 SettingManager::setBackupSlots(uint8_t numSlots)
 {
-    this->backup.slots = numSlots;
+    this->backup.numSlots = numSlots;
 }
 
 std::weak_ptr<SettingData>

--- a/tests/src/backup.cpp
+++ b/tests/src/backup.cpp
@@ -14,7 +14,7 @@ TEST(Backup, Basic)
     auto doSave = [&] {
         std::error_code ec;
         Backup::saveWithBackup(
-            "files/out.backup.basic.json", {.enabled = true, .slots = 3},
+            "files/out.backup.basic.json", {.enabled = true, .numSlots = 3},
             [&](const auto &path, auto &ec) {
                 writeCalls++;
                 std::ofstream of(path, std::ios::out);
@@ -71,7 +71,7 @@ TEST(Backup, Single)
     auto doSave = [&] {
         std::error_code ec;
         Backup::saveWithBackup(
-            "files/out.backup.single.json", {.enabled = true, .slots = 1},
+            "files/out.backup.single.json", {.enabled = true, .numSlots = 1},
             [&](const auto &path, auto &ec) {
                 writeCalls++;
                 std::ofstream of(path, std::ios::out);
@@ -126,7 +126,7 @@ TEST(Backup, Disabled)
     auto doSave = [&] {
         std::error_code ec;
         Backup::saveWithBackup(
-            "files/out.backup.disabled.json", {.enabled = false, .slots = 3},
+            "files/out.backup.disabled.json", {.enabled = false, .numSlots = 3},
             [&](const auto &path, auto &ec) {
                 writeCalls++;
                 std::ofstream of(path, std::ios::out);
@@ -183,7 +183,7 @@ TEST(Backup, Failing)
     std::error_code ec;
     auto doSave = [&](bool fail) {
         Backup::saveWithBackup(
-            "files/out.backup.failing.json", {.enabled = true, .slots = 3},
+            "files/out.backup.failing.json", {.enabled = true, .numSlots = 3},
             [&](const auto &path, auto &ec) {
                 writeCalls++;
                 std::ofstream of(path, std::ios::out);


### PR DESCRIPTION
`#define Q_SLOTS`
`#define slots Q_SLOTS`
![](https://cdn.betterttv.net/emote/54fa8f1401e468494b85b537/1x)