### PR TITLE
feat: Save only if change has come in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Breaking: Save methods now return a `SaveResult` enum instead of a bool. (#100)
-- Minor: Setting managers can be configured to only save if a change has come in through its `set` function (e.g. by changing the value of a setting) with the `SaveMethod::CompareBeforeSave` flag. (#100)
+- Minor: Setting managers can be configured to only save if a change has come in through its `set` function (e.g. by changing the value of a setting) with the `SaveMethod::OnlySaveIfChanged` flag. (#100)
 
 ## v0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Breaking: Save methods now return a `SaveResult` enum instead of a bool. (#100)
-- Minor: Setting managers can be configured to only save if a change has come in through its `set` function (e.g. by changing the value of a setting) with the `SaveMethod::OnlySaveIfChanged` flag. (#100)
+- Breaking: Save methods now return a `SaveResult` enum instead of a bool. (#105)
+- Minor: Setting managers can be configured to only save if a change has come in through its `set` function (e.g. by changing the value of a setting) with the `SaveMethod::OnlySaveIfChanged` flag. (#105)
 
 ## v0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Breaking: Save methods now return a `SaveResult` enum instead of a bool. (#100)
+- Minor: Setting managers can be configured to only save if a change has come in through its `set` function (e.g. by changing the value of a setting) with the `SaveMethod::CompareBeforeSave` flag. (#100)
+
 ## v0.2.2
 
 - Bugfix: Renamed `slots` in the backup options to `numSlots` to avoid conflicts with Qt (#92)

--- a/include/pajlada/settings/settingmanager.hpp
+++ b/include/pajlada/settings/settingmanager.hpp
@@ -135,7 +135,7 @@ public:
         /// are detected, no backup will be created
         CompareBeforeSave = (1ULL << 3ULL),
 
-        // Force user to manually call SettingsManager::save() to save
+        /// Force user to manually call SettingsManager::save() to save
         SaveManually = 0,
         SaveAllTheTime = SaveOnExit | SaveOnSettingChange,
     } saveMethod = SaveMethod::SaveOnExit;

--- a/include/pajlada/settings/settingmanager.hpp
+++ b/include/pajlada/settings/settingmanager.hpp
@@ -32,6 +32,15 @@ public:
         JSONParseError,
     };
 
+    enum class SaveResult : std::uint8_t {
+        /// Saving the settings to a file failed
+        /// We currently don't elaborate why it failed
+        Failed,
+
+        /// The settings were successfully saved to a file
+        Success,
+    };
+
     // Print given document json data prettily
     void pp(const std::string &prefix = std::string());
     static void gPP(const std::string &prefix = std::string());
@@ -94,17 +103,17 @@ public:
     // Load from given path
     LoadError loadFrom(const std::filesystem::path &path);
 
-    static bool gSave(const std::filesystem::path &path = {});
-    static bool gSaveAs(const std::filesystem::path &path);
+    static SaveResult gSave(const std::filesystem::path &path = {});
+    static SaveResult gSaveAs(const std::filesystem::path &path);
 
     // Force a settings save
     // It is recommended to run this every now and then unless your application
     // is crash free
     // Save to given path and set path as the default path (or save from default
     // path if filePath is a nullptr)
-    bool save(const std::filesystem::path &path = {});
+    SaveResult save(const std::filesystem::path &path = {});
     // Save to given path
-    bool saveAs(const std::filesystem::path &path);
+    SaveResult saveAs(const std::filesystem::path &path);
 
 private:
     bool writeTo(const std::filesystem::path &path);

--- a/include/pajlada/settings/settingmanager.hpp
+++ b/include/pajlada/settings/settingmanager.hpp
@@ -130,10 +130,12 @@ public:
         SaveOnExit = (1ULL << 1ULL),
         SaveOnSettingChange = (1ULL << 2ULL),
 
-        /// Compare the last payload before actually making any filesystem changes
-        /// This is done before the backup options are read, so if no changes
-        /// are detected, no backup will be created
-        CompareBeforeSave = (1ULL << 3ULL),
+        /// Only perform the save (& and backup) if a call to `set` has come in, meaning
+        /// some setting has changed.
+        ///
+        /// Pairs well with `SettingOption::CompareBeforeSet`, ensuring `set` does not
+        /// set the `hasUnsavedChanges` flag unnecessarily.
+        OnlySaveIfChanged = (1ULL << 3ULL),
 
         /// Force user to manually call SettingsManager::save() to save
         SaveManually = 0,

--- a/src/settings/settingmanager.cpp
+++ b/src/settings/settingmanager.cpp
@@ -457,7 +457,7 @@ SettingManager::save(const std::filesystem::path &path)
 SettingManager::SaveResult
 SettingManager::saveAs(const std::filesystem::path &path)
 {
-    if (this->hasSaveMethodFlag(SaveMethod::CompareBeforeSave) &&
+    if (this->hasSaveMethodFlag(SaveMethod::OnlySaveIfChanged) &&
         !this->hasUnsavedChanges) {
         // No save necessary - no changes have been made
         return SaveResult::Skipped;

--- a/src/settings/settingmanager.cpp
+++ b/src/settings/settingmanager.cpp
@@ -426,7 +426,7 @@ SettingManager::loadFrom(const std::filesystem::path &_path)
     return LoadError::NoError;
 }
 
-bool
+SettingManager::SaveResult
 SettingManager::gSave(const std::filesystem::path &path)
 {
     const auto &instance = SettingManager::getInstance();
@@ -434,7 +434,7 @@ SettingManager::gSave(const std::filesystem::path &path)
     return instance->save(path);
 }
 
-bool
+SettingManager::SaveResult
 SettingManager::gSaveAs(const std::filesystem::path &path)
 {
     const auto &instance = SettingManager::getInstance();
@@ -442,7 +442,7 @@ SettingManager::gSaveAs(const std::filesystem::path &path)
     return instance->saveAs(path);
 }
 
-bool
+SettingManager::SaveResult
 SettingManager::save(const std::filesystem::path &path)
 {
     if (!path.empty()) {
@@ -452,7 +452,7 @@ SettingManager::save(const std::filesystem::path &path)
     return this->saveAs(this->filePath);
 }
 
-bool
+SettingManager::SaveResult
 SettingManager::saveAs(const std::filesystem::path &path)
 {
     std::error_code ec;
@@ -465,7 +465,11 @@ SettingManager::saveAs(const std::filesystem::path &path)
         },
         ec);
 
-    return !ec;
+    if (ec) {
+        return SaveResult::Failed;
+    }
+
+    return SaveResult::Success;
 }
 
 bool

--- a/tests/files/correct.save.compare_before_save.json
+++ b/tests/files/correct.save.compare_before_save.json
@@ -1,0 +1,3 @@
+{
+    "compare_before_save_lol": 15
+}

--- a/tests/src/common.cpp
+++ b/tests/src/common.cpp
@@ -56,7 +56,7 @@ LoadFile(const std::string &fileName, SettingManager *sm)
     return sm->loadFrom(path.c_str()) == SettingManager::LoadError::NoError;
 }
 
-bool
+pajlada::Settings::SettingManager::SaveResult
 SaveFile(const std::string &fileName, SettingManager *sm)
 {
     if (sm == nullptr) {

--- a/tests/src/common.hpp
+++ b/tests/src/common.hpp
@@ -11,8 +11,9 @@ bool FilesMatch(const std::string &fileName1, const std::string &fileName2);
 
 bool LoadFile(const std::string &fileName,
               pajlada::Settings::SettingManager *sm = nullptr);
-bool SaveFile(const std::string &fileName,
-              pajlada::Settings::SettingManager *sm = nullptr);
+pajlada::Settings::SettingManager::SaveResult SaveFile(
+    const std::string &fileName,
+    pajlada::Settings::SettingManager *sm = nullptr);
 
 bool RemoveFile(const std::string &path);
 

--- a/tests/src/map.cpp
+++ b/tests/src/map.cpp
@@ -3,6 +3,7 @@
 #include "common.hpp"
 
 using namespace pajlada::Settings;
+using SaveResult = pajlada::Settings::SettingManager::SaveResult;
 
 TEST(Map, Simple)
 {
@@ -22,7 +23,7 @@ TEST(Map, Simple)
 
     EXPECT_TRUE(keys == SettingManager::getObjectKeys("/map"));
 
-    EXPECT_TRUE(SettingManager::gSaveAs("files/out.simplemap.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.simplemap.json"));
 }
 
 TEST(Map, Complex)
@@ -62,5 +63,5 @@ TEST(Map, Complex)
     EXPECT_TRUE(any_cast<int>(innerArrayMap["b"]) == 2);
     EXPECT_TRUE(any_cast<int>(innerArrayMap["c"]) == 3);
 
-    EXPECT_TRUE(SettingManager::gSaveAs("files/out.complexmap.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.complexmap.json"));
 }

--- a/tests/src/misc.cpp
+++ b/tests/src/misc.cpp
@@ -13,6 +13,7 @@
 
 using namespace pajlada::Settings;
 using namespace pajlada::test;
+using SaveResult = pajlada::Settings::SettingManager::SaveResult;
 
 TEST(Misc, StdAny)
 {
@@ -39,7 +40,7 @@ TEST(Misc, Array)
     // been changed
     EXPECT_TRUE(SettingManager::arraySize("/array") == 3);
 
-    EXPECT_TRUE(SettingManager::gSaveAs("files/out.array_test.json") == true);
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.array_test.json"));
 
     EXPECT_TRUE(SettingManager::arraySize("/array") == 3);
 }
@@ -75,7 +76,7 @@ TEST(Misc, Vector)
 
     test = x;
 
-    EXPECT_TRUE(SettingManager::gSaveAs("files/out.vector.json") == true);
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.vector.json"));
 }
 
 TEST(Misc, ChannelManager)
@@ -105,7 +106,7 @@ TEST(Misc, ChannelManager)
     }
 
     EXPECT_TRUE(manager.channels.size() == pajlada::test::NUM_CHANNELS);
-    EXPECT_TRUE(SettingManager::gSaveAs("files/out.test3.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.test3.json"));
     EXPECT_TRUE(manager.channels.size() == pajlada::test::NUM_CHANNELS);
 }
 

--- a/tests/src/remove.cpp
+++ b/tests/src/remove.cpp
@@ -1,6 +1,7 @@
 #include "common.hpp"
 
 using namespace pajlada::Settings;
+using SaveResult = pajlada::Settings::SettingManager::SaveResult;
 
 TEST(Remove, Simple)
 {
@@ -20,11 +21,11 @@ TEST(Remove, Simple)
     EXPECT_TRUE(b == 10);
     EXPECT_TRUE(c == 0);
 
-    EXPECT_TRUE(SettingManager::gSaveAs("files/out.pre.removesetting.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.pre.removesetting.json"));
 
     EXPECT_TRUE(a.remove());
 
-    EXPECT_TRUE(SettingManager::gSaveAs("files/out.post.removesetting.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.post.removesetting.json"));
 
     EXPECT_TRUE(!FilesMatch("out.pre.removesetting.json",
                             "out.post.removesetting.json"));
@@ -60,8 +61,8 @@ TEST(Remove, Nested)
     EXPECT_TRUE(d.isValid());
     EXPECT_TRUE(e.isValid());
 
-    EXPECT_TRUE(
-        SettingManager::gSaveAs("files/out.removenestedsetting.state1.json"));
+    EXPECT_EQ(SaveResult::Success,
+              SaveFile("out.removenestedsetting.state1.json"));
     EXPECT_TRUE(FilesMatch("out.removenestedsetting.state1.json",
                            "in.removenestedsetting.state1.json"));
 
@@ -73,8 +74,8 @@ TEST(Remove, Nested)
     EXPECT_TRUE(d.isValid());
     EXPECT_TRUE(e.isValid());
 
-    EXPECT_TRUE(
-        SettingManager::gSaveAs("files/out.removenestedsetting.state2.json"));
+    EXPECT_EQ(SaveResult::Success,
+              SaveFile("out.removenestedsetting.state2.json"));
     EXPECT_TRUE(FilesMatch("out.removenestedsetting.state2.json",
                            "in.removenestedsetting.state2.json"));
 
@@ -86,8 +87,8 @@ TEST(Remove, Nested)
     EXPECT_TRUE(d.isValid());
     EXPECT_TRUE(e.isValid());
 
-    EXPECT_TRUE(
-        SettingManager::gSaveAs("files/out.removenestedsetting.state3.json"));
+    EXPECT_EQ(SaveResult::Success,
+              SaveFile("out.removenestedsetting.state3.json"));
     EXPECT_TRUE(FilesMatch("out.removenestedsetting.state3.json",
                            "in.removenestedsetting.state3.json"));
 }

--- a/tests/src/save.cpp
+++ b/tests/src/save.cpp
@@ -234,3 +234,28 @@ TEST(Save, SaveBackupSymlink)
     EXPECT_TRUE(fs::is_symlink(bp2));
     EXPECT_TRUE(fs::exists(tp2));
 }
+
+TEST(Save, CompareBeforeSave)
+{
+    auto sm = std::make_shared<SettingManager>();
+    sm->saveMethod = SettingManager::SaveMethod::CompareBeforeSave;
+
+    EXPECT_EQ(SaveResult::Skipped,
+              SaveFile("out.save.compare_before_save.json", sm.get()));
+
+    Setting<int> s("/compare_before_save_lol", sm);
+
+    EXPECT_EQ(SaveResult::Skipped,
+              SaveFile("out.save.compare_before_save.json", sm.get()));
+
+    s.setValue(15);
+
+    EXPECT_EQ(SaveResult::Success,
+              SaveFile("out.save.compare_before_save.json", sm.get()));
+
+    EXPECT_TRUE(FilesMatch("out.save.compare_before_save.json",
+                           "correct.save.compare_before_save.json"));
+
+    EXPECT_EQ(SaveResult::Skipped,
+              SaveFile("out.save.compare_before_save.json", sm.get()));
+}

--- a/tests/src/save.cpp
+++ b/tests/src/save.cpp
@@ -235,10 +235,10 @@ TEST(Save, SaveBackupSymlink)
     EXPECT_TRUE(fs::exists(tp2));
 }
 
-TEST(Save, CompareBeforeSave)
+TEST(Save, OnlySaveIfChanged)
 {
     auto sm = std::make_shared<SettingManager>();
-    sm->saveMethod = SettingManager::SaveMethod::CompareBeforeSave;
+    sm->saveMethod = SettingManager::SaveMethod::OnlySaveIfChanged;
 
     EXPECT_EQ(SaveResult::Skipped,
               SaveFile("out.save.compare_before_save.json", sm.get()));

--- a/tests/src/save.cpp
+++ b/tests/src/save.cpp
@@ -6,6 +6,7 @@
 #include "common.hpp"
 
 using namespace pajlada::Settings;
+using SaveResult = pajlada::Settings::SettingManager::SaveResult;
 
 namespace fs = std::filesystem;
 
@@ -19,7 +20,7 @@ TEST(Save, Int)
 
     Setting<int>::set("/lol", 10);
 
-    EXPECT_TRUE(SaveFile("out.save.save_int.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.save.save_int.json"));
 
     EXPECT_TRUE(
         FilesMatch("out.save.save_int.json", "correct.save.save_int.json"));
@@ -31,7 +32,7 @@ TEST(Save, DoNotWriteToJSON)
 
     Setting<int>::set("/lol", 10);
 
-    EXPECT_TRUE(SaveFile("out.save.save_int.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.save.save_int.json"));
 
     EXPECT_TRUE(
         FilesMatch("out.save.save_int.json", "correct.save.save_int.json"));
@@ -62,7 +63,7 @@ TEST(Save, Symlink)
 
     Setting<int>::set("/lol", 10);
 
-    EXPECT_TRUE(sm->saveAs(ps.c_str()));
+    EXPECT_EQ(SaveResult::Success, SaveFile("save.symlink.json"));
 
     EXPECT_TRUE(fs::is_symlink(ps));
 }
@@ -118,25 +119,25 @@ TEST(Save, Backup)
 
     EXPECT_TRUE(!fs::exists("files/out.backup.json"));
 
-    EXPECT_TRUE(sm->save());
+    EXPECT_EQ(SaveResult::Success, sm->save());
 
     EXPECT_TRUE(fs::exists("files/out.backup.json"));
     EXPECT_TRUE(!fs::exists("files/out.backup.json.bkp-1"));
 
-    EXPECT_TRUE(sm->save());
+    EXPECT_EQ(SaveResult::Success, sm->save());
 
     EXPECT_TRUE(fs::exists("files/out.backup.json"));
     EXPECT_TRUE(fs::exists("files/out.backup.json.bkp-1"));
     EXPECT_TRUE(!fs::exists("files/out.backup.json.bkp-2"));
 
-    EXPECT_TRUE(sm->save());
+    EXPECT_EQ(SaveResult::Success, sm->save());
 
     EXPECT_TRUE(fs::exists("files/out.backup.json"));
     EXPECT_TRUE(fs::exists("files/out.backup.json.bkp-1"));
     EXPECT_TRUE(fs::exists("files/out.backup.json.bkp-2"));
     EXPECT_TRUE(!fs::exists("files/out.backup.json.bkp-3"));
 
-    EXPECT_TRUE(sm->save());
+    EXPECT_EQ(SaveResult::Success, sm->save());
 
     EXPECT_TRUE(fs::exists("files/out.backup.json"));
     EXPECT_TRUE(fs::exists("files/out.backup.json.bkp-1"));
@@ -165,7 +166,7 @@ TEST(Save, SaveSymlink)
         setting.setValue(13);
     }
 
-    EXPECT_TRUE(sm->save());
+    EXPECT_EQ(SaveResult::Success, sm->save());
 
     EXPECT_TRUE(fs::exists(bp));
     EXPECT_TRUE(fs::is_symlink(bp));
@@ -212,7 +213,7 @@ TEST(Save, SaveBackupSymlink)
     EXPECT_TRUE(!fs::exists(tp));
 
     // Save to base file (following the symlink)
-    EXPECT_TRUE(sm->save());
+    EXPECT_EQ(SaveResult::Success, sm->save());
 
     EXPECT_TRUE(fs::is_symlink(bp));
     EXPECT_TRUE(fs::exists(tp));
@@ -220,7 +221,7 @@ TEST(Save, SaveBackupSymlink)
     EXPECT_TRUE(!fs::exists(tp1));
 
     // Save to base file, should create bkp-1
-    EXPECT_TRUE(sm->save());
+    EXPECT_EQ(SaveResult::Success, sm->save());
 
     EXPECT_TRUE(fs::exists(tp1));
 
@@ -228,7 +229,7 @@ TEST(Save, SaveBackupSymlink)
     EXPECT_TRUE(!fs::exists(tp2));
 
     // Save to base file, should follow bkp-2 and save a file there
-    EXPECT_TRUE(sm->save());
+    EXPECT_EQ(SaveResult::Success, sm->save());
 
     EXPECT_TRUE(fs::is_symlink(bp2));
     EXPECT_TRUE(fs::exists(tp2));

--- a/tests/src/serialize.cpp
+++ b/tests/src/serialize.cpp
@@ -3,6 +3,7 @@
 #include "common.hpp"
 
 using namespace pajlada::Settings;
+using SaveResult = pajlada::Settings::SettingManager::SaveResult;
 
 TEST(Serialize, VectorBeforeLoading)
 {
@@ -44,7 +45,7 @@ TEST(Serialize, VectorMisc)
 
     a = newData;
 
-    EXPECT_TRUE(SaveFile("out.serialize.vector.str.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.serialize.vector.str.json"));
 
     EXPECT_TRUE(FilesMatch("in.serialize.vector.str.state1.json",
                            "out.serialize.vector.str.json"));
@@ -86,7 +87,8 @@ TEST(Serialize, StdAnyVectorString)
 
     a = newData;
 
-    EXPECT_TRUE(SaveFile("out.serialize.any.vector.str.json"));
+    EXPECT_EQ(SaveResult::Success,
+              SaveFile("out.serialize.any.vector.str.json"));
 
     EXPECT_TRUE(FilesMatch("in.serialize.vector.str.state1.json",
                            "out.serialize.any.vector.str.json"));
@@ -130,7 +132,8 @@ TEST(Serialize, StdAnyVectorAny)
 
     a = newData;
 
-    EXPECT_TRUE(SaveFile("out.serialize.any.vector.str.json"));
+    EXPECT_EQ(SaveResult::Success,
+              SaveFile("out.serialize.any.vector.str.json"));
 
     EXPECT_TRUE(FilesMatch("in.serialize.vector.str.state1.json",
                            "out.serialize.any.vector.str.json"));
@@ -175,7 +178,7 @@ TEST(Serialize, Int4)
     SettingManager::clear();
     Setting<int> a("/a");
     EXPECT_TRUE(LoadFile("in.serialize.int.json"));
-    EXPECT_TRUE(SaveFile("out.serialize.int.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.serialize.int.json"));
 
     EXPECT_TRUE(FilesMatch("in.serialize.int.json", "out.serialize.int.json"));
 }
@@ -237,7 +240,7 @@ TEST(Serialize, Bool)
     EXPECT_TRUE(a.getValue() == true);
     val = a;
     EXPECT_TRUE(val == true);
-    EXPECT_TRUE(SaveFile("out.serialize.bool.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.serialize.bool.json"));
     EXPECT_TRUE(
         FilesMatch("in.serialize.bool.json", "out.serialize.bool.json"));
 
@@ -246,7 +249,7 @@ TEST(Serialize, Bool)
     EXPECT_TRUE(a.getValue() == false);
     val = a;
     EXPECT_TRUE(val == false);
-    EXPECT_TRUE(SaveFile("out.serialize.bool.json"));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.serialize.bool.json"));
     EXPECT_TRUE(
         FilesMatch("in.serialize.bool.false.json", "out.serialize.bool.json"));
 }

--- a/tests/src/static.cpp
+++ b/tests/src/static.cpp
@@ -3,6 +3,7 @@
 #include "common.hpp"
 
 using namespace pajlada::Settings;
+using SaveResult = pajlada::Settings::SettingManager::SaveResult;
 
 namespace {
 
@@ -113,5 +114,5 @@ TEST(Static, Static)
 
     f7 = 0.f;
 
-    EXPECT_TRUE(SaveFile("out.test2.json", ssm.get()));
+    EXPECT_EQ(SaveResult::Success, SaveFile("out.test2.json", ssm.get()));
 }


### PR DESCRIPTION
Example usage (which probably compiles):

```c++
auto sm = std::make_shared<SettingManager>();
sm->saveMethod = SettingManager::SaveMethod::OnlySaveIfChanged;

// nothing changed, save won't do anything
assert(sm->save() == SettingManager::SaveResult::Skipped);

sm::set("/foo", rapidjson::Value(5));

// something changed, save to file
assert(sm->save() == SettingManager::SaveResult::Success);

// nothing changed, save won't do anything
assert(sm->save() == SettingManager::SaveResult::Skipped);
```
