### PR TITLE
deps: update `signals`

### DIFF
--- a/include/pajlada/settings/setting.hpp
+++ b/include/pajlada/settings/setting.hpp
@@ -440,7 +440,7 @@ public:
             if (ptr != nullptr) {
                 d.CopyFrom(*ptr, d.GetAllocator());
             }
-            connection.invoke(std::move(d), detail::onConnectArgs());
+            lockedSetting->updated.invoke(d, detail::onConnectArgs());
         }
 
         this->managedConnections.emplace_back(
@@ -467,7 +467,7 @@ public:
             if (ptr != nullptr) {
                 d.CopyFrom(*ptr, d.GetAllocator());
             }
-            connection.invoke(std::move(d), detail::onConnectArgs());
+            lockedSetting->updated.invoke(d, detail::onConnectArgs());
         }
 
         userDefinedManagedConnections.emplace_back(


### PR DESCRIPTION
Updates the `signals` library.

Since `Connection::invoke` was removed, `connectJSON` had to be updated. Looks like I missed this when searching for it. However, this is a good example for [my concern](https://github.com/pajlada/signals/pull/44#discussion_r2296305735). We invoked the signal with `(rapidjson::Document, SignalArgs)` even though it takes `(const rapidjson::GenericValue&, const SignalArgs&)`. This still works out in this case, but we could've passed anything there like `(int, bool)` and the compiler would be fine.