### PR TITLE
fix: assert that setting is valid in setValue

### DIFF
--- a/include/pajlada/settings/setting.hpp
+++ b/include/pajlada/settings/setting.hpp
@@ -325,6 +325,8 @@ public:
     bool
     setValue(const Type &newValue, SignalArgs &&args = SignalArgs())
     {
+        assert(this->isValid());
+
         if (this->optionEnabled(SettingOption::CompareBeforeSet)) {
             args.compareBeforeSet = true;
         }

--- a/tests/src/remove.cpp
+++ b/tests/src/remove.cpp
@@ -157,4 +157,6 @@ TEST(Remove, Invalidated)
 
     // After the setting is removed, it can no longer be used
     ASSERT_FALSE(a.isValid());
+
+    EXPECT_DEATH({ a = 7; }, "Assertion `this->isValid\\(\\)' failed");
 }

--- a/tests/src/remove.cpp
+++ b/tests/src/remove.cpp
@@ -158,5 +158,5 @@ TEST(Remove, Invalidated)
     // After the setting is removed, it can no longer be used
     ASSERT_FALSE(a.isValid());
 
-    EXPECT_DEATH({ a = 7; }, "Assertion `this->isValid\\(\\)' failed");
+    EXPECT_DEATH({ a = 7; }, "this->isValid\\(\\)");
 }


### PR DESCRIPTION
If the setting is invalid, setValue is a no-op.
