### PR TITLE
ci: use Chatterino fork of ilammy/msvc-dev-cmd action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Enable Developer Command Prompt
         if: startsWith(matrix.os, 'windows')
-        uses: ilammy/msvc-dev-cmd@v1.13.0
+        uses: Chatterino/msvc-dev-cmd@v2.0.5
 
       - name: Install the latest version of uv
         if: matrix.package-manager == 'conan'


### PR DESCRIPTION
I left out external/serialize/.github/workflows/build-windows.yml since I think that'll get updated through dependabot/the other project anyways.